### PR TITLE
fix(ci): remove redundant iterator conversion

### DIFF
--- a/PE端/src/core/config.rs
+++ b/PE端/src/core/config.rs
@@ -487,7 +487,7 @@ impl ConfigFileManager {
     }
 
     fn has_install_artifacts() -> bool {
-        Self::scan_letters().into_iter().any(|letter| {
+        Self::scan_letters().any(|letter| {
             Path::new(&format!("{}:\\{}", letter, Self::INSTALL_MARKER)).exists()
                 || Path::new(&format!(
                     "{}:\\{}\\{}",


### PR DESCRIPTION
## Root cause

The release workflow pins Rust 1.88 and runs Clippy with `-D warnings`. `ConfigFileManager::scan_letters()` already returns an iterator, so calling `.into_iter()` triggered `clippy::useless-conversion` and blocked the 2026.7.23 release.

## Fix

Remove only the redundant `.into_iter()` call. Scanning, short-circuit behavior, and install semantics are unchanged.

## Verified with Rust 1.88

- `cargo +1.88.0 fmt --all --check`
- release-workflow Clippy command with `-D warnings`
- PE tests: 84 passed
- workspace test targets: compiled successfully
- `git diff --check`

`AGENTS.md` was reviewed; no file responsibility or safety-boundary documentation changes are required for this one-line lint-only fix.